### PR TITLE
Revamp home page with hero and social sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -16,56 +16,135 @@
   <link rel="stylesheet" href="./styles/main.css" />
 </head>
 <body>
-  <div class="container">
-    <header class="header" role="banner">
+  <header class="header" role="banner">
+    <div class="container">
       <a class="brand" href="index.html" aria-label="LLH home">
         <div class="logo" aria-hidden="true"></div>
         <span class="brand-name">LLH</span>
       </a>
       <nav class="nav" aria-label="Primary">
+        <a class="navlink" href="index.html">Home</a>
         <a class="navlink" href="music.html">Music</a>
         <a class="navlink" href="about.html">About</a>
         <a class="navlink" href="contact.html">Contact</a>
       </nav>
-    </header>
+    </div>
+  </header>
 
-    <main id="main" class="main" tabindex="-1">
-      <section class="hero hero-split" aria-labelledby="hero-title">
-        <div class="hero-left">
-          <h1 id="hero-title" class="hero-title">LLH</h1>
-          <p class="hero-sub">Dreamy textures, cinematic arcs, and rap-adjacent energy.</p>
-          <div class="socials" aria-label="Social links">
-            <a class="chip" href="https://open.spotify.com/artist/" target="_blank" rel="noopener">Spotify</a>
-            <a class="chip" href="https://music.apple.com/" target="_blank" rel="noopener">Apple Music</a>
-            <a class="chip" href="https://instagram.com/" target="_blank" rel="noopener">Instagram</a>
-            <a class="chip" href="https://youtube.com/@" target="_blank" rel="noopener">YouTube</a>
+  <main id="main" class="main" tabindex="-1">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="container hero-content">
+        <h1 id="hero-title" class="hero-title">LLH</h1>
+        <p class="hero-tagline">Dreamy textures, cinematic arcs, and rap-adjacent energy.</p>
+        <a class="btn btn-primary listen-btn" href="#" target="_blank" rel="noopener">Listen Now</a>
+      </div>
+    </section>
+
+    <section class="latest-release" aria-labelledby="release-heading">
+      <div class="container release-inner">
+        <div class="release-art">
+          <img src="assets/covers/cover-default.webp" alt="Album cover" />
+        </div>
+        <div class="release-info">
+          <h2 id="release-heading" class="section-title">Latest Release</h2>
+          <p>Check out the newest track from LLH, blending dreamy textures with cinematic vibes.</p>
+          <div class="stream-buttons">
+            <a class="btn stream-btn" href="#" target="_blank" rel="noopener" aria-label="Spotify">
+              <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="12" cy="12" r="12" fill="currentColor"/>
+                <path d="M7 10c3-1 7-1 10 1M7 14c2.8-.8 6-.8 8.5.5M7 17c2-.6 4.3-.6 6 .4" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round"/>
+              </svg>
+              Spotify
+            </a>
+            <a class="btn stream-btn" href="#" target="_blank" rel="noopener" aria-label="Apple Music">
+              <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="9" cy="17" r="3" fill="currentColor"/>
+                <path d="M14 7v10a3 3 0 1 0 3-3h-3" fill="currentColor"/>
+              </svg>
+              Apple Music
+            </a>
+            <a class="btn stream-btn" href="#" target="_blank" rel="noopener" aria-label="YouTube">
+              <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="2" y="5" width="20" height="14" rx="3" fill="currentColor"/>
+                <polygon points="10,9 15,12 10,15" fill="#fff"/>
+              </svg>
+              YouTube
+            </a>
           </div>
         </div>
-        <div class="hero-right">
-          <div class="hero-bg" style="background-image:url('https://via.placeholder.com/400x400?text=Background');"></div>
-          <div id="featured-release" class="featured-release"></div>
+      </div>
+    </section>
+
+    <section class="social-links" aria-labelledby="social-heading">
+      <div class="container">
+        <h2 id="social-heading" class="section-title">Follow Me</h2>
+        <div class="social-icons">
+          <a href="#" target="_blank" rel="noopener" aria-label="Spotify">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="12" fill="currentColor"/>
+              <path d="M7 10c3-1 7-1 10 1M7 14c2.8-.8 6-.8 8.5.5M7 17c2-.6 4.3-.6 6 .4" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="#" target="_blank" rel="noopener" aria-label="Instagram">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="2" y="2" width="20" height="20" rx="5" fill="currentColor"/>
+              <circle cx="12" cy="12" r="5" fill="#fff"/>
+            </svg>
+          </a>
+          <a href="#" target="_blank" rel="noopener" aria-label="YouTube">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="2" y="5" width="20" height="14" rx="3" fill="currentColor"/>
+              <polygon points="10,9 15,12 10,15" fill="#fff"/>
+            </svg>
+          </a>
+          <a href="#" target="_blank" rel="noopener" aria-label="TikTok">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M15 3v5a4 4 0 1 1-3-1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </a>
+          <a href="#" target="_blank" rel="noopener" aria-label="Bandcamp">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <polygon points="4,4 20,12 4,20" fill="currentColor"/>
+            </svg>
+          </a>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <section id="music" class="section" aria-labelledby="albums-heading">
-        <h2 id="albums-heading" class="section-title">Latest Releases</h2>
-        <div id="albums" class="grid" role="list" data-limit="3"></div>
-      </section>
+    <section id="about" class="section about-short" aria-labelledby="about-heading">
+      <div class="container">
+        <h2 id="about-heading" class="section-title">About Me</h2>
+        <p class="muted">LLH is a 20-year-old artist and producer from Germany. He blends electronic textures with rap sensibilities and cinematic arcs to craft immersive soundscapes.</p>
+      </div>
+    </section>
+  </main>
 
-      <section id="about" class="section about-short" aria-labelledby="about-heading">
-        <h2 id="about-heading" class="section-title">About</h2>
-        <p class="muted">LLH is a 20-year-old artist and producer from Germany. He blends electronic textures with rap sensibilities and cinematic arcs.</p>
-      </section>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <p>© <span id="year"></span> LLH — All rights reserved. <a href="mailto:contact@example.com">contact@example.com</a></p>
+      <div class="footer-social">
+        <a href="#" target="_blank" rel="noopener" aria-label="Spotify">
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="12" fill="currentColor"/>
+            <path d="M7 10c3-1 7-1 10 1M7 14c2.8-.8 6-.8 8.5.5M7 17c2-.6 4.3-.6 6 .4" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round"/>
+          </svg>
+        </a>
+        <a href="#" target="_blank" rel="noopener" aria-label="Instagram">
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="2" y="2" width="20" height="20" rx="5" fill="currentColor"/>
+            <circle cx="12" cy="12" r="5" fill="#fff"/>
+          </svg>
+        </a>
+        <a href="#" target="_blank" rel="noopener" aria-label="YouTube">
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="2" y="5" width="20" height="14" rx="3" fill="currentColor"/>
+            <polygon points="10,9 15,12 10,15" fill="#fff"/>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </footer>
 
-      <div class="split"></div>
-
-    </main>
-    <footer class="footer" role="contentinfo">
-      <p>© <span id="year"></span> LLH — All rights reserved.</p>
-    </footer>
-  </div>
-
-  <noscript>JavaScript is required to load albums.</noscript>
   <script defer src="./scripts/app.js"></script>
 </body>
 </html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -16,7 +16,7 @@
 
     /* Layout */
     .container{max-width:1100px; margin:0 auto; padding:24px}
-    header{display:flex; align-items:center; justify-content:space-between; gap:12px; padding-block:10px}
+    .header .container{display:flex; align-items:center; justify-content:space-between; gap:12px; padding-block:10px}
     .brand{display:flex; align-items:center; gap:14px}
     .logo{width:38px; height:38px; border-radius:14px; background:linear-gradient(145deg,#111,#1c1d22); display:grid; place-items:center; box-shadow:0 4px 24px rgba(0,0,0,.4)}
     .logo svg{opacity:.9}
@@ -90,4 +90,133 @@
 
     .album.upcoming {
       border-style: solid;
+    }
+
+    /* ---- Home page revamp styles ---- */
+    .header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--bg);
+    }
+
+    .hero {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      background: linear-gradient(135deg, #1b1b20, #0f0f12);
+      padding: 0 24px;
+    }
+
+    .hero-title {
+      font-size: clamp(48px, 10vw, 96px);
+      margin: 0;
+    }
+
+    .hero-tagline {
+      margin-top: 12px;
+      max-width: 600px;
+      color: var(--muted);
+    }
+
+    .listen-btn {
+      margin-top: 24px;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #0f0f12;
+      font-weight: 600;
+    }
+
+    .btn-primary:hover {
+      background: #a0e8ff;
+    }
+
+    .latest-release {
+      margin-top: 60px;
+    }
+
+    .release-inner {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 24px;
+      align-items: center;
+    }
+
+    .release-art img {
+      width: 260px;
+      border-radius: 16px;
+    }
+
+    .release-info {
+      flex: 1;
+    }
+
+    .stream-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 16px;
+    }
+
+    .stream-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .social-links {
+      margin-top: 60px;
+      text-align: center;
+    }
+
+    .social-icons {
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      margin-top: 20px;
+    }
+
+    .social-icons a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: #17171c;
+      transition: transform 0.2s, background 0.2s;
+    }
+
+    .social-icons a:hover {
+      transform: scale(1.1);
+      background: #1e1f26;
+    }
+
+    .social-icons svg {
+      width: 24px;
+      height: 24px;
+    }
+
+    .footer {
+      text-align: center;
+    }
+
+    .footer-social {
+      margin-top: 12px;
+      display: flex;
+      justify-content: center;
+      gap: 16px;
+    }
+
+    .footer-social a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
     }


### PR DESCRIPTION
## Summary
- Redesign home page with a sticky header, hero call-to-action, latest release showcase, social links, and contact footer.
- Add responsive styles for new sections and basic node_modules ignore.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e90a4bbfc83239aee71d8368c9bf5