### PR TITLE
Revamp home page with hero and social sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/assets/albums.json
+++ b/assets/albums.json
@@ -18,9 +18,10 @@
     "link": "..."
   },
   {
-    "title": "secret",
+    "title": "Born for More",
     "type": "album",
     "releaseDate": "2025-08-20",
-    "link": "..."
+    "link": "...",
+    "featured": true
   }
 ]

--- a/index.html
+++ b/index.html
@@ -16,56 +16,111 @@
   <link rel="stylesheet" href="./styles/main.css" />
 </head>
 <body>
-  <div class="container">
-    <header class="header" role="banner">
+  <header class="header" role="banner">
+    <div class="container">
       <a class="brand" href="index.html" aria-label="LLH home">
         <div class="logo" aria-hidden="true"></div>
         <span class="brand-name">LLH</span>
       </a>
       <nav class="nav" aria-label="Primary">
+        <a class="navlink" href="index.html">Home</a>
         <a class="navlink" href="music.html">Music</a>
         <a class="navlink" href="about.html">About</a>
         <a class="navlink" href="contact.html">Contact</a>
       </nav>
-    </header>
+    </div>
+  </header>
 
-    <main id="main" class="main" tabindex="-1">
-      <section class="hero hero-split" aria-labelledby="hero-title">
-        <div class="hero-left">
+  <main id="main" class="main" tabindex="-1">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="container hero-wrapper">
+        <div class="hero-main">
+          <img class="hero-photo" src="assets/LLH.webp" alt="LLH performing" />
           <h1 id="hero-title" class="hero-title">LLH</h1>
-          <p class="hero-sub">Dreamy textures, cinematic arcs, and rap-adjacent energy.</p>
-          <div class="socials" aria-label="Social links">
-            <a class="chip" href="https://open.spotify.com/artist/" target="_blank" rel="noopener">Spotify</a>
-            <a class="chip" href="https://music.apple.com/" target="_blank" rel="noopener">Apple Music</a>
-            <a class="chip" href="https://instagram.com/" target="_blank" rel="noopener">Instagram</a>
-            <a class="chip" href="https://youtube.com/@" target="_blank" rel="noopener">YouTube</a>
+          <p class="hero-tagline">Dreamy textures, cinematic arcs, and rap-adjacent energy.</p>
+          <a id="listen-btn" class="btn btn-primary listen-btn" href="#" target="_blank" rel="noopener">Listen Now</a>
+        </div>
+        <div class="hero-featured">
+          <img id="featured-cover" class="featured-cover" src="assets/covers/cover-default.webp" alt="Featured cover" />
+          <div class="featured-info">
+            <p id="featured-label" class="featured-label">Upcoming</p>
+            <h2 id="featured-title" class="featured-title">&ldquo;Born for More&rdquo;</h2>
+            <p id="featured-subtext" class="featured-subtext">Album</p>
           </div>
         </div>
-        <div class="hero-right">
-          <div class="hero-bg" style="background-image:url('https://via.placeholder.com/400x400?text=Background');"></div>
-          <div id="featured-release" class="featured-release"></div>
+      </div>
+    </section>
+
+    <section class="social-links" aria-labelledby="social-heading">
+      <div class="container">
+        <h2 id="social-heading" class="section-title">Follow Me</h2>
+        <div class="social-icons">
+          <a href="#" target="_blank" rel="noopener" aria-label="Spotify">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="12" fill="currentColor"/>
+              <path d="M7 10c3-1 7-1 10 1M7 14c2.8-.8 6-.8 8.5.5M7 17c2-.6 4.3-.6 6 .4" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="#" target="_blank" rel="noopener" aria-label="Instagram">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="2" y="2" width="20" height="20" rx="5" fill="currentColor"/>
+              <circle cx="12" cy="12" r="5" fill="#fff"/>
+            </svg>
+          </a>
+          <a href="#" target="_blank" rel="noopener" aria-label="YouTube">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="2" y="5" width="20" height="14" rx="3" fill="currentColor"/>
+              <polygon points="10,9 15,12 10,15" fill="#fff"/>
+            </svg>
+          </a>
+          <a href="#" target="_blank" rel="noopener" aria-label="TikTok">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M15 3v5a4 4 0 1 1-3-1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </a>
+          <a href="#" target="_blank" rel="noopener" aria-label="Bandcamp">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+              <polygon points="4,4 20,12 4,20" fill="currentColor"/>
+            </svg>
+          </a>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <section id="music" class="section" aria-labelledby="albums-heading">
-        <h2 id="albums-heading" class="section-title">Latest Releases</h2>
-        <div id="albums" class="grid" role="list" data-limit="3"></div>
-      </section>
+    <section id="about" class="section about-short" aria-labelledby="about-heading">
+      <div class="container">
+        <h2 id="about-heading" class="section-title">About Me</h2>
+        <p class="muted">LLH is a 20-year-old artist and producer from Germany. He blends electronic textures with rap sensibilities and cinematic arcs to craft immersive soundscapes.</p>
+      </div>
+    </section>
+  </main>
 
-      <section id="about" class="section about-short" aria-labelledby="about-heading">
-        <h2 id="about-heading" class="section-title">About</h2>
-        <p class="muted">LLH is a 20-year-old artist and producer from Germany. He blends electronic textures with rap sensibilities and cinematic arcs.</p>
-      </section>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <p>© <span id="year"></span> LLH — All rights reserved. <a href="mailto:contact@example.com">contact@example.com</a></p>
+      <div class="footer-social">
+        <a href="#" target="_blank" rel="noopener" aria-label="Spotify">
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="12" fill="currentColor"/>
+            <path d="M7 10c3-1 7-1 10 1M7 14c2.8-.8 6-.8 8.5.5M7 17c2-.6 4.3-.6 6 .4" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round"/>
+          </svg>
+        </a>
+        <a href="#" target="_blank" rel="noopener" aria-label="Instagram">
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="2" y="2" width="20" height="20" rx="5" fill="currentColor"/>
+            <circle cx="12" cy="12" r="5" fill="#fff"/>
+          </svg>
+        </a>
+        <a href="#" target="_blank" rel="noopener" aria-label="YouTube">
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="2" y="5" width="20" height="14" rx="3" fill="currentColor"/>
+            <polygon points="10,9 15,12 10,15" fill="#fff"/>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </footer>
 
-      <div class="split"></div>
-
-    </main>
-    <footer class="footer" role="contentinfo">
-      <p>© <span id="year"></span> LLH — All rights reserved.</p>
-    </footer>
-  </div>
-
-  <noscript>JavaScript is required to load albums.</noscript>
   <script defer src="./scripts/app.js"></script>
 </body>
 </html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -184,10 +184,40 @@ function setCopyrightYear() {
   if (el) el.textContent = new Date().getFullYear();
 }
 
+async function loadFeaturedAlbum() {
+  const coverEl = $('#featured-cover');
+  const labelEl = $('#featured-label');
+  const titleEl = $('#featured-title');
+  const subtextEl = $('#featured-subtext');
+  const listenBtn = $('#listen-btn');
+  if (!coverEl || !labelEl || !titleEl) return;
+
+  try {
+    const raw = await fetchJSON(CONFIG.jsonPath);
+    const items = Array.isArray(raw) ? raw : [];
+    const featured = items.find(a => a.featured);
+    if (!featured) return;
+    featured.cover = await resolveCover(featured);
+    coverEl.src = featured.cover;
+    coverEl.alt = `Cover of ${featured.title}`;
+    const upcoming = isFuture(featured.releaseDate);
+    labelEl.textContent = upcoming ? 'Upcoming' : 'Latest Release';
+    titleEl.textContent = `“${featured.title}”`;
+    if (subtextEl) {
+      const type = featured.type ? featured.type.charAt(0).toUpperCase() + featured.type.slice(1) : '';
+      subtextEl.textContent = type;
+    }
+    if (listenBtn && featured.link) listenBtn.href = featured.link;
+  } catch (err) {
+    console.error('Failed to load featured album:', err);
+  }
+}
+
 
 // Init
 
 document.addEventListener('DOMContentLoaded', () => {
   copyrightYear = setCopyrightYear();
   loadAndRenderAlbums();
+  loadFeaturedAlbum();
 });

--- a/styles/main.css
+++ b/styles/main.css
@@ -16,7 +16,7 @@
 
     /* Layout */
     .container{max-width:1100px; margin:0 auto; padding:24px}
-    header{display:flex; align-items:center; justify-content:space-between; gap:12px; padding-block:10px}
+    .header .container{display:flex; align-items:center; justify-content:space-between; gap:12px; padding-block:10px}
     .brand{display:flex; align-items:center; gap:14px}
     .logo{width:38px; height:38px; border-radius:14px; background:linear-gradient(145deg,#111,#1c1d22); display:grid; place-items:center; box-shadow:0 4px 24px rgba(0,0,0,.4)}
     .logo svg{opacity:.9}
@@ -26,9 +26,6 @@
     .navlink{padding:8px 12px; border-radius:12px; background:#141418; color:#dde1ee}
     .navlink:hover{background:#191a20}
 
-    .hero{padding:40px 0 24px}
-    .hero h2{font-size:clamp(28px, 3vw + 18px, 48px); line-height:1.1; margin:0 0 12px}
-    .hero p{color:var(--muted); margin:0}
 
     .socials{display:flex; gap:10px; margin-top:18px}
     .chip{display:inline-flex; align-items:center; gap:8px; padding:10px 12px; border-radius:999px; background:#17171c; color:#e8eaf3}
@@ -90,4 +87,151 @@
 
     .album.upcoming {
       border-style: solid;
+    }
+
+    /* ---- Home page revamp styles ---- */
+    .header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--bg);
+    }
+
+    .hero {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      background: linear-gradient(135deg, #1b1b20, #0f0f12);
+      padding: 0 24px;
+    }
+
+    .hero-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 40px;
+      width: 100%;
+    }
+
+    @media (min-width: 768px) {
+      .hero-wrapper {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+
+    .hero-main {
+      max-width: 420px;
+    }
+
+    .hero-photo {
+      width: 100%;
+      max-width: 240px;
+      border-radius: 16px;
+      margin-bottom: 24px;
+    }
+
+    .hero-title {
+      font-size: clamp(48px, 10vw, 96px);
+      margin: 0;
+    }
+
+    .hero-tagline {
+      margin-top: 12px;
+      max-width: 600px;
+      color: var(--muted);
+    }
+
+    .listen-btn {
+      margin-top: 24px;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #0f0f12;
+      font-weight: 600;
+    }
+
+    .btn-primary:hover {
+      background: #a0e8ff;
+    }
+
+    .hero-featured {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+    }
+
+    .featured-cover {
+      width: 260px;
+      border-radius: 16px;
+    }
+
+    .featured-label {
+      margin: 0;
+      text-transform: uppercase;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .featured-title {
+      margin: 4px 0;
+      font-size: clamp(24px, 5vw, 40px);
+    }
+
+    .featured-subtext {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .social-links {
+      margin-top: 60px;
+      text-align: center;
+    }
+
+    .social-icons {
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      margin-top: 20px;
+    }
+
+    .social-icons a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: #17171c;
+      transition: transform 0.2s, background 0.2s;
+    }
+
+    .social-icons a:hover {
+      transform: scale(1.1);
+      background: #1e1f26;
+    }
+
+    .social-icons svg {
+      width: 24px;
+      height: 24px;
+    }
+
+    .footer {
+      text-align: center;
+    }
+
+    .footer-social {
+      margin-top: 12px;
+      display: flex;
+      justify-content: center;
+      gap: 16px;
+    }
+
+    .footer-social a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
     }


### PR DESCRIPTION
## Summary
- Showcase a featured release alongside the hero intro, pulling album data flagged as `featured`.
- Add responsive styles for the two-column hero layout and remove the redundant latest release block.
- Extend site script and album metadata to populate the hero and listen button dynamically.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e90a4bbfc83239aee71d8368c9bf5