### PR TITLE
Revamp music page with hero, discography grid and album modal

### DIFF
--- a/music.html
+++ b/music.html
@@ -12,7 +12,7 @@
   <!-- Hint the browser that we'll fetch the JSON for this page -->
   <link rel="preload" as="fetch" href="assets/albums.json" crossorigin="anonymous" />
 </head>
-<body>
+<body class="music-page">
   <!-- Top nav identical to index.html -->
   <header class="header" role="banner">
     <div class="container">
@@ -28,53 +28,41 @@
   </header>
 
   <main id="main" class="main" tabindex="-1">
-  <section class="section" aria-labelledby="music-heading">
-    <div class="container">
-      <h1 id="music-heading" class="section-title">Music</h1>
-      <p class="muted">
-        Featured & upcoming first, then the full discography. Notes are at the end.
-        Populated from <code>assets/albums.json</code>.
-      </p>
-    </div>
-  </section>
+    <!-- Featured hero -->
+    <section id="hero" class="hero" aria-labelledby="featured-heading">
+      <div class="container" id="featured" aria-live="polite"></div>
+    </section>
 
-  <!-- 1) Featured / Upcoming -->
-  <section class="section" aria-labelledby="featured-heading">
-    <div class="container">
-      <h2 id="featured-heading" class="section-title">Featured / Upcoming</h2>
-      <div id="featured" class="grid" aria-live="polite"></div>
-    </div>
-  </section>
-
-  <!-- 2) Discography -->
-  <section class="section" aria-labelledby="discog-heading">
-    <div class="container">
-      <h2 id="discog-heading" class="section-title">Discography</h2>
-      <div id="discography" class="grid" aria-live="polite"></div>
-    </div>
-  </section>
-
-  <!-- 3) Notes (separate, scrollable, linkable) -->
-  <section class="section" aria-labelledby="notes-heading">
-    <div class="container">
-      <h2 id="notes-heading" class="section-title">Notes</h2>
-      <div id="notes" class="notes" aria-live="polite">
-        <!-- JS will inject a list of <article> blocks like:
-        <article class="note" id="note-<slug>">
-          <h3 class="note-title">Title <small class="note-meta">(<time datetime="YYYY-MM-DD">YYYY</time> · Album)</small></h3>
-          <div class="note-body"><p>…</p></div>
-        </article>
-        -->
+    <!-- Discography grid -->
+    <section class="section" aria-labelledby="discog-heading">
+      <div class="container">
+        <h2 id="discog-heading" class="section-title">Discography</h2>
+        <div id="discography" class="discography-grid" aria-live="polite"></div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <noscript>
-    <div class="container">
-      <p class="muted">JavaScript is disabled, so releases can’t be loaded. Enable JavaScript to see the discography.</p>
-    </div>
-  </noscript>
-</main>
+    <!-- Closing call-to-action -->
+    <section class="cta-section">
+      <div class="container cta-inner">
+        <p class="cta-text">Follow on Spotify for new releases.</p>
+        <a class="btn btn-primary" href="#" target="_blank" rel="noopener">Follow on Spotify</a>
+        <div class="cta-socials">
+          <a href="#" aria-label="Instagram" target="_blank" rel="noopener">IG</a>
+          <a href="#" aria-label="YouTube" target="_blank" rel="noopener">YT</a>
+          <a href="#" aria-label="Twitter" target="_blank" rel="noopener">TW</a>
+        </div>
+      </div>
+    </section>
+
+    <noscript>
+      <div class="container">
+        <p class="muted">JavaScript is disabled, so releases can’t be loaded. Enable JavaScript to see the discography.</p>
+      </div>
+    </noscript>
+  </main>
+
+  <!-- Floating album modal -->
+  <div id="album-modal" class="modal hidden" aria-hidden="true"></div>
 
 
   <footer class="footer" role="contentinfo">
@@ -103,8 +91,8 @@
     </div>
   </footer>
 
-  <!-- Page script: detects this is the music page and calls renderMusicPage(),
-       which reads assets/albums.json via CONFIG.jsonPath and builds the layout. -->
+    <!-- Page scripts: main.js handles shared widgets; music-page.js builds the hero,
+         discography grid and modal from assets/albums.json. -->
   <script type="module" src="scripts/main.js"></script>
   <script type="module" src="scripts/music-page.js"></script>
 </body>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,22 +1,16 @@
 // scripts/main.js
 
 import { setCopyrightYear, getAverageColor } from './utils.js';
-import { loadAndRenderAlbums, loadFeaturedAlbum, loadLatestReleaseAlbum, renderMusicPage } from './albums.js';
+import { loadAndRenderAlbums, loadFeaturedAlbum, loadLatestReleaseAlbum } from './albums.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   // Basic page setup
   setCopyrightYear();
 
   // Decide which albums renderer to use
-  const isMusicPage =
-    window.location.pathname.endsWith('/music.html') ||
-    document.getElementById('music-heading') ||      // fallback: element check
-    document.getElementById('discography-grid');     // future-proof
+  const isMusicPage = document.body.classList.contains('music-page');
 
-  if (isMusicPage) {
-    // New unified Featured + Discography + Notes experience
-    renderMusicPage();
-  } else {
+  if (!isMusicPage) {
     // Old list renderer (does nothing if #albums isn't present)
     loadAndRenderAlbums();
   }

--- a/scripts/music-page.js
+++ b/scripts/music-page.js
@@ -1,296 +1,149 @@
-// scripts/music-page.js
-// Page-specific renderer for music.html. Keeps global nav/footer intact.
-// HTML structure expected (already in music.html):
-//  - #featured (Featured / Upcoming)
-//  - #discography (Grid)
-//  - #notes (Separate Notes section with long-form stories)
-//
-// notes.json schema (flexible):
-// [
-//   {
-//     "slug": "born-for-more",             // must match album slug (auto from title if none in albums.json)
-//     "title": "Born For More — Story & Process",
-//     "updatedAt": "2025-08-14",
-//     "quote": "We recorded the hook at 2am with the city humming outside.",
-//     "body": "Plain text with blank lines = paragraphs.\n\nOr provide HTML.",
-//     "sections": [
-//       {"title": "Writing", "body": "text/html here"},
-//       {"title": "Production", "body": "text/html here"}
-//     ],
-//     "media": [
-//       {"type": "image", "src": "assets/notes/bfm-session.jpg", "alt": "Session"},
-//       {"type": "audio", "src": "assets/notes/bfm-demo.mp3"}
-//     ]
-//   }
-// ]
-
 (function(){
   const ALBUMS_URL = 'assets/albums.json';
-  const NOTES_URL  = 'assets/notes.json';
 
-  document.addEventListener('DOMContentLoaded', initMusicPage);
+  document.addEventListener('DOMContentLoaded', init);
 
-  async function initMusicPage(){
-    const featuredEl = document.querySelector('#featured');
-    const discogEl   = document.querySelector('#discography');
-    const notesEl    = document.querySelector('#notes');
-    if (!featuredEl || !discogEl || !notesEl) return;
+  async function init(){
+    const heroEl = document.getElementById('featured');
+    const gridEl = document.getElementById('discography');
+    const modalEl = document.getElementById('album-modal');
+    if (!heroEl || !gridEl || !modalEl) return;
 
     try {
-      const [albums, notes] = await Promise.all([
-        fetchJSON(ALBUMS_URL),
-        fetchJSON(NOTES_URL).catch(() => ([])) // tolerate missing notes.json during dev
-      ]);
-
-      const normAlbums = (albums || []).map(normalizeAlbum).sort(sortByDateDesc);
-      const notesIndex = indexNotes(notes || []);
-
-      renderFeatured(featuredEl, normAlbums);
-      renderDiscography(discogEl, normAlbums, notesIndex);
-      renderNotes(notesEl, normAlbums, notesIndex);
-
-    } catch (err){
+      const raw = await fetch(ALBUMS_URL, { credentials: 'omit' });
+      if (!raw.ok) throw new Error('Failed to load albums.json');
+      const albums = (await raw.json()).map(normalizeAlbum).sort(sortByDateDesc);
+      renderHero(heroEl, albums);
+      renderDiscography(gridEl, albums);
+    } catch (err) {
       console.error('[music-page] init failed', err);
-      showError(err);
+      gridEl.innerHTML = '<p class="muted">Failed to load releases.</p>';
     }
   }
 
-  // -------------------- Data helpers --------------------
-  async function fetchJSON(url){
-    const res = await fetch(url, { credentials: 'omit' });
-    if (!res.ok) throw new Error(`Failed to load ${url}: ${res.status}`);
-    return res.json();
-  }
-
   function normalizeAlbum(a){
-    const date = a.releaseDate ? new Date(a.releaseDate) : null;
     const slug = a.slug || slugify(a.title);
-    const type = (a.type || 'album').toLowerCase();
     return {
       title: a.title,
-      type,
+      type: (a.type || 'album').toLowerCase(),
+      releaseDate: a.releaseDate || '',
       link: a.link || '#',
-      releaseDate: a.releaseDate || null,
-      date,
-      year: date ? String(date.getFullYear()) : '',
-      featured: !!a.featured,
-      upcoming: date ? date > new Date() : false,
-      slug,
+      notes: Array.isArray(a.notes) ? a.notes : [],
       cover: a.cover || `assets/covers/${slug}.webp`,
-      ...a
+      featured: !!a.featured,
+      slug
     };
   }
 
   function sortByDateDesc(a,b){
-    const at = a.date ? a.date.getTime() : 0;
-    const bt = b.date ? b.date.getTime() : 0;
-    return bt - at;
+    return (b.releaseDate || '').localeCompare(a.releaseDate || '');
   }
 
-  function indexNotes(notesArray){
-    const idx = new Map();
-    if (Array.isArray(notesArray)){
-      for (const n of notesArray){
-        const slug = n.slug || slugify(n.title || '');
-        if (!slug) continue;
-        idx.set(slug, {
-          slug,
-          title: n.title || null,
-          body: n.body || '',
-          updatedAt: n.updatedAt || null,
-          sections: Array.isArray(n.sections) ? n.sections : null,
-          quote: n.quote || null,
-          media: Array.isArray(n.media) ? n.media : null
-        });
-      }
-    } else if (notesArray && typeof notesArray === 'object'){
-      for (const [slug, n] of Object.entries(notesArray)){
-        idx.set(slug, {
-          slug,
-          title: n.title || null,
-          body: n.body || '',
-          updatedAt: n.updatedAt || null,
-          sections: Array.isArray(n.sections) ? n.sections : null,
-          quote: n.quote || null,
-          media: Array.isArray(n.media) ? n.media : null
-        });
-      }
-    }
-    return idx;
-  }
-
-  function slugify(str){
-    return String(str || '')
-      .toLowerCase()
-      .normalize('NFKD')
-      .replace(/\p{Diacritic}/gu, '')
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '');
-  }
-
-  // -------------------- Rendering --------------------
-  function renderFeatured(root, albums){
-    // Show explicit featured first; else show upcoming (future-dated albums)
-    const featured = albums.filter(a => a.featured);
-    const upcoming = albums.filter(a => a.upcoming && a.type === 'album');
-    const items = featured.length ? featured : upcoming;
-
-    root.innerHTML = '';
-    if (!items.length){
-      root.innerHTML = '<p class="muted">No featured or upcoming releases right now.</p>';
+  function renderHero(root, albums){
+    const a = albums.find(x => x.featured) || albums[0];
+    if (!a){
+      root.innerHTML = '<p class="muted">No featured release.</p>';
       return;
     }
 
-    for (const a of items){
-      root.appendChild(albumCard(a, { highlight: true, showType: true }));
-    }
+    const hero = el('div', { class: 'hero-content' });
+    const art = el('div', { class: 'hero-art' });
+    art.appendChild(el('img', { src: a.cover, alt: `${a.title} cover` }));
+    const info = el('div', { class: 'hero-info' });
+    info.innerHTML = `
+      <h1 class="hero-title">${a.title}</h1>
+      <p class="hero-meta">${capitalize(a.type)}${a.releaseDate ? ' • ' + a.releaseDate : ''}</p>
+      ${a.notes[0] ? `<p class="hero-tagline">${escapeHTML(a.notes[0])}</p>` : ''}
+      <div class="hero-actions"><a class="btn btn-primary listen-btn" href="${a.link}" target="_blank" rel="noopener">Listen</a></div>
+    `;
+    hero.append(art, info);
+
+    hero.addEventListener('click', ev => {
+      if (ev.target.closest('a')) return;
+      openModal(a);
+    });
+
+    root.innerHTML = '';
+    root.appendChild(hero);
   }
 
-  function renderDiscography(root, albums, notesIndex){
+  function renderDiscography(root, albums){
     root.innerHTML = '';
-
     for (const a of albums){
-      const hasNotes = notesIndex.has(a.slug);
-      const card = albumCard(a, { showType: true, showYear: true, hasNotes });
-
-      if (hasNotes){
-        // Minimal “Notes” link (no excerpt/teaser)
-        const notesLink = el('a', {
-          class: 'btn',
-          href: `#note-${a.slug}`,
-          'aria-label': `Read notes for ${a.title}`
-        }, 'Notes');
-        card.querySelector('.actions')?.appendChild(notesLink);
-      }
-
+      const card = albumCard(a);
       root.appendChild(card);
     }
   }
 
-  function renderNotes(root, albums, notesIndex){
-    root.innerHTML = '';
-
-    // Only render notes that exist, in the same order as albums (newest->oldest)
-    const withNotes = albums.filter(a => notesIndex.has(a.slug));
-    if (!withNotes.length){
-      root.innerHTML = '<p class="muted">No notes available yet.</p>';
-      return;
-    }
-
-    for (const a of withNotes){
-      const n = notesIndex.get(a.slug);
-      const id = `note-${a.slug}`;
-
-      const article = el('article', { class: 'note', id });
-
-      // Title (+ compact meta)
-      const h = el('h3', { class: 'note-title' });
-      const metaBits = [];
-      if (a.year) metaBits.push(a.year);
-      if (a.type) metaBits.push(capitalize(a.type));
-      const meta = metaBits.length ? ` (${metaBits.join(' · ')})` : '';
-      h.textContent = `${n.title || a.title}${meta}`;
-      article.appendChild(h);
-
-      // Optional pull-quote
-      if (n.quote){
-        article.appendChild(el('div', { class: 'note-quote' }, n.quote));
-      }
-
-      // Body (plain text → paragraphs; HTML passes through)
-      const body = el('div', { class: 'note-body' });
-      body.innerHTML = asHTML(n.body);
-      article.appendChild(body);
-
-      // Sections
-      if (n.sections){
-        for (const sec of n.sections){
-          const secWrap = el('section', { class: 'note-section' });
-          if (sec.title) secWrap.appendChild(el('h4', { class: 'note-section-title' }, sec.title));
-          const secBody = el('div');
-          secBody.innerHTML = asHTML(sec.body || '');
-          secWrap.appendChild(secBody);
-          article.appendChild(secWrap);
-        }
-      }
-
-      // Media
-      if (n.media && n.media.length){
-        const mediaWrap = el('div', { class: 'note-media' });
-        for (const m of n.media){
-          if (m.type === 'image'){
-            const fig = el('figure');
-            const img = el('img', { src: m.src, alt: m.alt || '' });
-            fig.appendChild(img);
-            if (m.caption) fig.appendChild(el('figcaption', {}, m.caption));
-            mediaWrap.appendChild(fig);
-          } else if (m.type === 'audio'){
-            mediaWrap.appendChild(el('audio', { controls: true, src: m.src }));
-          } else if (m.type === 'video'){
-            mediaWrap.appendChild(el('video', { controls: true, src: m.src }));
-          }
-        }
-        article.appendChild(mediaWrap);
-      }
-
-      // Back link to discography heading (if present in your HTML)
-      article.appendChild(el('div', { class: 'note-back' }));
-      article.lastChild.innerHTML = '<a href="#discog-heading">↥ Back to discography</a>';
-
-      root.appendChild(article);
-    }
-  }
-
-  function albumCard(a, opts={}){
-    const { highlight=false, showType=false, showYear=false } = opts;
-    const card = el('div', { class: `album${highlight ? ' highlight' : ''}` });
-
-    // Cover
-    const coverWrap = el('div', { class: 'cover' });
-    const coverImg = el('img', { class: 'cover', alt: `${a.title} cover`, src: a.cover });
-    coverWrap.innerHTML = '';
-    coverWrap.appendChild(coverImg);
-
-    // Meta
-    const meta = el('div', { class: 'meta' });
-
-    // Title row with optional 'Single' badge inline
-    const titleRow = el('div', { style: 'display:flex;align-items:center;gap:8px;' });
-    const title = el('div', { class: 'title' }, a.title);
-    titleRow.appendChild(title);
-    if (a.type === 'single') {
-      titleRow.appendChild(badge('Single', 'badge-single'));
-    }
-
-    const sub = el('div', { class: 'year' });
-    sub.textContent = [ showYear ? a.year : null, showType ? capitalize(a.type) : null ]
-      .filter(Boolean)
-      .join(' • ');
-
-    const actions = el('div', { class: 'actions' });
-    const listen = el('a', { class: 'btn', href: a.link || '#', target: '_blank', rel: 'noopener' }, 'Listen');
-    actions.appendChild(listen);
-
-    meta.append(titleRow, sub, actions);
-    card.append(coverWrap, meta);
+  function albumCard(a){
+    const card = el('article', { class: 'album-card', tabindex: '0' });
+    card.innerHTML = `
+      <img class="album-cover" src="${a.cover}" alt="${a.title} cover">
+      <h3 class="album-title">${a.title}</h3>
+      <p class="album-meta">${capitalize(a.type)}${a.releaseDate ? ' • ' + a.releaseDate : ''}</p>
+      ${a.notes[0] ? `<p class="album-blurb">${escapeHTML(a.notes[0])}</p>` : ''}
+    `;
+    card.addEventListener('click', () => openModal(a));
+    card.addEventListener('keydown', e => { if (e.key === 'Enter') openModal(a); });
     return card;
   }
 
-  function badge(text, extraClass=''){
-    return el('span', { class: `badge ${extraClass}`.trim(), 'aria-label': text }, text);
+  function openModal(album){
+    const modal = document.getElementById('album-modal');
+    modal.innerHTML = `
+      <div class="modal-backdrop"></div>
+      <article class="modal-content" role="dialog" aria-modal="true">
+        <button class="modal-close" aria-label="Close">&times;</button>
+        <header class="modal-header">
+          <img class="modal-cover" src="${album.cover}" alt="${album.title} cover">
+          <div class="modal-info">
+            <h2>${album.title}</h2>
+            <p>${capitalize(album.type)}${album.releaseDate ? ' • ' + album.releaseDate : ''}</p>
+            <p><a class="btn btn-primary" href="${album.link}" target="_blank" rel="noopener">Listen</a></p>
+          </div>
+        </header>
+        <div class="modal-body">
+          ${album.notes.map(p => `<p>${escapeHTML(p)}</p>`).join('')}
+        </div>
+      </article>
+    `;
+
+    modal.classList.remove('hidden');
+    document.body.classList.add('modal-open');
+
+    const closeBtn = modal.querySelector('.modal-close');
+    const backdrop = modal.querySelector('.modal-backdrop');
+    const focusables = modal.querySelectorAll('a, button');
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    function trap(e){
+      if (e.key === 'Tab'){
+        if (e.shiftKey && document.activeElement === first){
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last){
+          e.preventDefault();
+          first.focus();
+        }
+      } else if (e.key === 'Escape'){ close(); }
+    }
+
+    function close(){
+      modal.classList.add('hidden');
+      modal.innerHTML = '';
+      document.body.classList.remove('modal-open');
+      document.removeEventListener('keydown', trap);
+    }
+
+    document.addEventListener('keydown', trap);
+    closeBtn.addEventListener('click', close);
+    backdrop.addEventListener('click', close);
+    first.focus();
   }
 
-  // -------------------- Small utils --------------------
-  function el(tag, attrs={}, text){
-    const node = document.createElement(tag);
-    for (const [k,v] of Object.entries(attrs || {})){
-      if (v == null) continue;
-      if (k === 'class') node.className = v;
-      else if (k === 'style') node.setAttribute('style', v);
-      else node.setAttribute(k, v);
-    }
-    if (text != null) node.textContent = text;
-    return node;
+  function slugify(str){
+    return String(str || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
   }
 
   function capitalize(s){
@@ -298,119 +151,20 @@
     return s.charAt(0).toUpperCase() + s.slice(1);
   }
 
-  function asHTML(input){
-    const str = String(input || '').trim();
-    if (!str) return '';
-    const looksHTML = /<\w+[\s\S]*>/m.test(str);
-    if (looksHTML) return str;
-    return str
-      .split(/\n\n+/)
-      .map(para => `<p>${escapeHTML(para).replace(/\n/g, '<br>')}</p>`)
-      .join('\n');
+  function el(tag, attrs){
+    const node = document.createElement(tag);
+    for (const [k,v] of Object.entries(attrs || {})){
+      if (k === 'class') node.className = v;
+      else node.setAttribute(k, v);
+    }
+    return node;
   }
 
   function escapeHTML(s){
-    return String(s || '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+    return String(s || '').replace(/[&<>"']/g, c => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
   }
 
-  function showError(err){
-    const cont = document.querySelector('#discography');
-    if (cont){
-      cont.innerHTML = `<p class="muted">Failed to load releases. ${escapeHTML(err.message || String(err))}</p>`;
-    }
-  }
 })();
-
-// --- Stories / Notes ---
-async function renderStories({ albums }) {
-  const notesEl = document.getElementById('notes');
-  if (!notesEl) return;
-
-  // Load notes
-  const res = await fetch('assets/notes.json', { credentials: 'omit' });
-  const notes = await res.json();
-
-  // Map albums by title for grouping (or switch to albumSlug if you prefer)
-  const albumOrder = new Map(albums.map((a, i) => [a.title, i]));
-
-  // Group notes by album
-  const byAlbum = notes.reduce((acc, n) => {
-    const key = n.album || 'Other';
-    (acc[key] ||= []).push(n);
-    return acc;
-  }, {});
-
-  // Sort albums by their order from albums.json (fallback: alphabetic)
-  const albumKeys = Object.keys(byAlbum).sort((a, b) => {
-    const ai = albumOrder.has(a) ? albumOrder.get(a) : Infinity;
-    const bi = albumOrder.has(b) ? albumOrder.get(b) : Infinity;
-    return ai - bi || a.localeCompare(b);
-  });
-
-  // Render
-  const frag = document.createDocumentFragment();
-
-  for (const albumTitle of albumKeys) {
-    const h = document.createElement('h3');
-    h.className = 'album-group';
-    h.textContent = albumTitle;
-    frag.appendChild(h);
-
-    const wrap = document.createElement('div');
-    wrap.className = 'album-stories';
-
-    // newest first
-    const stories = byAlbum[albumTitle].slice().sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''));
-
-    for (const s of stories) {
-      const id = `story-${s.slug}`;
-      const excerpt = s.excerpt || (s.bodyHtml ? s.bodyHtml.replace(/<[^>]+>/g, '').trim().slice(0, 180) + '…' : '');
-
-      const article = document.createElement('article');
-      article.className = 'story';
-      article.id = id;
-
-      article.innerHTML = `
-        <details>
-          <summary>
-            <span class="story-title">${escapeHtml(s.title)}</span>
-            <span class="story-meta">${formatDate(s.updatedAt)} · ${escapeHtml(albumTitle)}</span>
-            <span class="story-excerpt">${escapeHtml(excerpt)}</span>
-            <span class="chevron" aria-hidden="true">▾</span>
-          </summary>
-          <div class="story-body">${s.bodyHtml || ''}</div>
-        </details>
-      `;
-      wrap.appendChild(article);
-    }
-
-    frag.appendChild(wrap);
-  }
-
-  notesEl.replaceChildren(frag);
-
-  // Deep-link: auto-open matching story if #hash present
-  const hash = decodeURIComponent(location.hash || '').replace(/^#/, '');
-  if (hash) {
-    const target = document.getElementById(hash) || document.getElementById(`story-${hash}`);
-    if (target) {
-      const det = target.querySelector('details');
-      if (det) det.open = true;
-      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }
-
-  // Helpers
-  function formatDate(iso) {
-    if (!iso) return '';
-    try {
-      const d = new Date(iso + 'T00:00:00Z');
-      return d.toISOString().slice(0, 10); // YYYY-MM-DD
-    } catch { return iso; }
-  }
-
-  function escapeHtml(str = '') {
-    return str.replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
-  }
-}
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -475,3 +475,46 @@
   .notes-wrap { grid-template-columns: 1fr; }
   .notes-toc { position: static; }
 }
+
+/* --- Music page layout --- */
+body.music-page .hero { padding: 60px 0; }
+body.music-page .hero-content { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 32px; }
+body.music-page .hero-art img { width: 300px; height: 300px; object-fit: cover; border-radius: 16px; box-shadow: 0 4px 32px rgba(0,0,0,0.3); }
+body.music-page .hero-info { max-width: 500px; }
+body.music-page .hero-title { font-size: clamp(32px,6vw,64px); margin: 0; }
+body.music-page .hero-meta { color: var(--muted); margin: 8px 0; }
+body.music-page .hero-tagline { margin: 8px 0 24px; }
+body.music-page .hero-actions .btn { font-size: 18px; padding: 12px 24px; }
+@media (min-width:768px){
+  body.music-page .hero-content{ flex-direction: row; text-align: left; }
+  body.music-page .hero-info{ text-align: left; }
+}
+
+body.music-page .discography-grid { display: grid; gap: 24px; }
+@media (max-width:639px){ body.music-page .discography-grid { grid-template-columns: 1fr; } }
+@media (min-width:640px) and (max-width:979px){ body.music-page .discography-grid { grid-template-columns: repeat(2,1fr); } }
+@media (min-width:980px){ body.music-page .discography-grid { grid-template-columns: repeat(3,1fr); } }
+
+body.music-page .album-card { background: var(--card); border:1px solid #1e2028; border-radius:16px; padding:16px; box-shadow:0 2px 6px rgba(0,0,0,0.2); transition:transform 0.2s, box-shadow 0.2s; cursor:pointer; display:flex; flex-direction:column; }
+body.music-page .album-card:hover { transform: scale(1.05); box-shadow:0 6px 20px rgba(0,0,0,0.4); }
+body.music-page .album-cover { width:100%; border-radius:12px; }
+body.music-page .album-title { margin:12px 0 4px; font-size:1.2rem; }
+body.music-page .album-meta { margin:0 0 8px; color:var(--muted); font-size:0.9rem; }
+body.music-page .album-blurb { margin:0; font-size:0.9rem; }
+
+body.music-page .modal.hidden { display:none; }
+body.music-page .modal { position:fixed; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,0.7); z-index:1000; }
+body.music-page .modal-content { background:var(--card); max-width:600px; width:90%; max-height:90vh; overflow:auto; border-radius:16px; padding:24px; box-shadow:0 10px 40px rgba(0,0,0,0.5); animation:fadeInUp .3s ease both; position:relative; }
+body.music-page .modal-header { display:flex; gap:20px; margin-bottom:16px; }
+body.music-page .modal-cover { width:150px; height:150px; object-fit:cover; border-radius:12px; }
+body.music-page .modal-close { position:absolute; top:8px; right:12px; background:none; border:none; color:var(--fg); font-size:28px; cursor:pointer; }
+body.music-page .modal-body p { margin-top:0; }
+@keyframes fadeInUp { from{ opacity:0; transform:translateY(20px);} to{opacity:1; transform:translateY(0);} }
+body.music-page.modal-open { overflow:hidden; }
+
+body.music-page .cta-section { text-align:center; padding:80px 24px; }
+body.music-page .cta-inner { display:flex; flex-direction:column; align-items:center; gap:16px; }
+body.music-page .cta-text { font-size:1.1rem; }
+body.music-page .cta-socials { display:flex; gap:20px; margin-top:8px; }
+body.music-page .cta-socials a { padding:8px; background:#17171c; border-radius:50%; transition:background .2s, transform .2s; }
+body.music-page .cta-socials a:hover { background:#1e1f26; transform:scale(1.1); }


### PR DESCRIPTION
## Summary
- Introduce hero section highlighting the featured album with cover, meta and listen button
- Build responsive discography card grid with hover scaling and modal detail view
- Add closing Spotify CTA and update main script detection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe799eaf483238f34de08065b6644