### PR TITLE
feat: centralize album card component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "artist-site",
+  "version": "1.0.0",
+  "description": "This project is a personal website showcasing my work as an artist. It includes sections for albums, a featured release, and links to social platforms.",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/scripts/albums.js
+++ b/scripts/albums.js
@@ -2,6 +2,7 @@
 
 import { CONFIG } from './config.js';
 import { $, slugify, isFuture, formatFancyDate, fetchJSON } from './utils.js';
+import { albumCard } from './components/album-card.js';
 
 let albumsCache;
 async function getAlbums() {
@@ -28,40 +29,6 @@ export async function resolveCover(album) {
   return CONFIG.defaultCover;
 }
 
-// Build markup for a single album card.
-function albumCardHTML(a, { highlight = false } = {}) {
-  const isSingle = a.type === 'single';
-  const future = isFuture(a.releaseDate);
-  const dateDisplay = formatFancyDate(a.releaseDate);
-  const badge = isSingle ? `<span class="badge badge-single">Single</span>` : '';
-  const cardClass = [
-    'album',
-    isSingle ? 'single' : '',
-    highlight ? 'highlight' : '',
-    future ? 'upcoming' : ''
-  ].filter(Boolean).join(' ');
-
-  const linkBtn = a.link ? `<a class="btn" href="${a.link}" target="_blank" rel="noopener">Listen</a>` : '';
-  const spotifyBtn = a.spotify ? `<a class="btn" href="${a.spotify}" target="_blank" rel="noopener">Spotify</a>` : '';
-  const appleBtn = a.apple ? `<a class="btn" href="${a.apple}" target="_blank" rel="noopener">Apple</a>` : '';
-
-  return `
-    <article class="${cardClass}" role="listitem">
-      <img class="cover" src="${a.cover}" alt="Cover of ${a.title}" loading="lazy"
-           onerror="this.onerror=null;this.src='${CONFIG.defaultCover}';" />
-      <div class="meta">
-        <div class="title">${a.title} ${badge}</div>
-        <div class="date">${dateDisplay}</div>
-        <div class="buttons">
-          ${linkBtn}
-          ${spotifyBtn}
-          ${appleBtn}
-        </div>
-      </div>
-    </article>
-  `;
-}
-
 // Render the albums listing and newest release section.
 export async function loadAndRenderAlbums() {
   const target = $('#albums');
@@ -78,19 +45,19 @@ export async function loadAndRenderAlbums() {
       html += `
         <section class="newest-release" aria-label="Upcoming Releases">
           <h3 class="newest-title">Upcoming Releases</h3>
-          ${upcoming.map(a => albumCardHTML(a, { highlight: true })).join('')}
+          ${upcoming.map(a => albumCard(a, { highlight: true }).outerHTML).join('')}
         </section>
       `;
     } else if (released.length > 0) {
       html += `
         <section class="newest-release" aria-label="Newest Release">
           <h3 class="newest-title">Newest Release</h3>
-          ${albumCardHTML(released[0], { highlight: true })}
+          ${albumCard(released[0], { highlight: true }).outerHTML}
         </section>
       `;
       finalReleased.shift();
     }
-    html += finalReleased.map(a => albumCardHTML(a)).join('');
+    html += finalReleased.map(a => albumCard(a).outerHTML).join('');
     target.innerHTML = html;
   } catch (err) {
     console.error('Failed to load albums:', err);

--- a/scripts/components/album-card.js
+++ b/scripts/components/album-card.js
@@ -1,0 +1,43 @@
+import { CONFIG } from '../config.js';
+import { isFuture, formatFancyDate } from '../utils.js';
+
+/**
+ * Build a DOM element representing a single album card.
+ * @param {Object} a - album metadata
+ * @param {Object} [opts]
+ * @param {boolean} [opts.highlight=false] - apply highlight styles
+ * @param {boolean} [opts.upcoming] - override upcoming status; defaults to release date check
+ * @returns {HTMLElement}
+ */
+export function albumCard(a, { highlight = false, upcoming } = {}) {
+  const isSingle = a.type === 'single';
+  const isUpcoming = upcoming ?? isFuture(a.releaseDate);
+  const dateDisplay = formatFancyDate(a.releaseDate);
+  const badgeHTML = isSingle ? '<span class="badge badge-single">Single</span>' : '';
+
+  const card = document.createElement('article');
+  card.className = [
+    'album',
+    isSingle ? 'single' : '',
+    highlight ? 'highlight' : '',
+    isUpcoming ? 'upcoming' : ''
+  ].filter(Boolean).join(' ');
+  card.setAttribute('role', 'listitem');
+
+  card.innerHTML = `
+    <img class="cover" src="${a.cover}" alt="Cover of ${a.title}" loading="lazy"
+         onerror="this.onerror=null;this.src='${CONFIG.defaultCover}';" />
+    <div class="meta">
+      <div class="title">${a.title} ${badgeHTML}</div>
+      <div class="date">${dateDisplay}</div>
+      <div class="buttons">
+        ${a.link ? `<a class="btn" href="${a.link}" target="_blank" rel="noopener">Listen</a>` : ''}
+        ${a.spotify ? `<a class="btn" href="${a.spotify}" target="_blank" rel="noopener">Spotify</a>` : ''}
+        ${a.apple ? `<a class="btn" href="${a.apple}" target="_blank" rel="noopener">Apple</a>` : ''}
+      </div>
+    </div>
+  `;
+
+  return card;
+}
+

--- a/scripts/music-page.js
+++ b/scripts/music-page.js
@@ -1,4 +1,5 @@
 import { slugify } from './utils.js';
+import { albumCard } from './components/album-card.js';
 
 const ALBUMS_URL = 'assets/albums.json';
 
@@ -75,21 +76,12 @@ function renderDiscography(root, albums){
   root.innerHTML = '';
   for (const a of albums){
     const card = albumCard(a);
+    card.tabIndex = 0;
+    card.classList.add('album-card');
+    card.addEventListener('click', () => openModal(a));
+    card.addEventListener('keydown', e => { if (e.key === 'Enter') openModal(a); });
     root.appendChild(card);
   }
-}
-
-function albumCard(a){
-  const card = el('article', { class: 'album-card', tabindex: '0' });
-  card.innerHTML = `
-    <img class="album-cover" src="${a.cover}" alt="${a.title} cover">
-    <h3 class="album-title">${a.title}</h3>
-    <p class="album-meta">${capitalize(a.type)}${a.releaseDate ? ' • ' + a.releaseDate : ''}</p>
-    ${a.notes[0] ? `<p class="album-blurb">${escapeHTML(a.notes[0])}</p>` : ''}
-  `;
-  card.addEventListener('click', () => openModal(a));
-  card.addEventListener('keydown', e => { if (e.key === 'Enter') openModal(a); });
-  return card;
 }
 
 function openModal(album){

--- a/tests/album-card.test.js
+++ b/tests/album-card.test.js
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { albumCard } from '../scripts/components/album-card.js';
+
+function setupDOM(){
+  global.document = {
+    createElement(tag){
+      return {
+        tagName: tag.toUpperCase(),
+        className: '',
+        attributes: {},
+        innerHTML: '',
+        setAttribute(name, value){ this.attributes[name] = value; },
+        get outerHTML(){
+          const attrs = Object.entries(this.attributes)
+            .map(([k,v]) => `${k}="${v}"`).join(' ');
+          const cls = this.className ? `class="${this.className}"` : '';
+          const all = [cls, attrs].filter(Boolean).join(' ');
+          return `<${tag}${all ? ' '+all : ''}>${this.innerHTML}</${tag}>`;
+        }
+      };
+    }
+  };
+}
+
+test('renders card with highlight and upcoming classes', () => {
+  setupDOM();
+  const album = { title: 'Test', type: 'single', releaseDate: '2099-01-01', cover: 'cover.jpg', link: 'l', spotify: 's', apple: 'a' };
+  const card = albumCard(album, { highlight: true });
+  assert.equal(card.tagName, 'ARTICLE');
+  assert(card.className.includes('album'));
+  assert(card.className.includes('highlight'));
+  assert(card.className.includes('upcoming'));
+  assert(card.innerHTML.includes('Listen'));
+});
+
+test('omits buttons when links missing', () => {
+  setupDOM();
+  const album = { title: 'NoLinks', type: 'album', releaseDate: '2020-01-01', cover: 'x' };
+  const card = albumCard(album);
+  assert(!card.innerHTML.includes('Spotify'));
+  assert(!card.innerHTML.includes('Apple'));
+});
+


### PR DESCRIPTION
## Summary
- extract shared `albumCard` component and reuse across pages
- refactor albums and music page to import shared component
- add tests for album card rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff348f5f483239822d3e3ef77f2fd